### PR TITLE
feat(seo): make sureshchaudhary.com canonical; fix canonicals, sitemap, project pages, and markdown surfaces

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -16,6 +16,19 @@ const nextConfig = {
             },
         ]
     },
+    async redirects() {
+        return [{
+            source: '/:path*',
+            has: [{ type: 'host', value: 'suresh.im' }],
+            destination: 'https://sureshchaudhary.com/:path*',
+            permanent: true,
+        }, {
+            source: '/:path*',
+            has: [{ type: 'host', value: 'www.sureshchaudhary.com' }],
+            destination: 'https://sureshchaudhary.com/:path*',
+            permanent: true,
+        }]
+    },
 }
 
 module.exports = nextConfig

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -16,7 +16,7 @@ Suresh Chaudhary is a Full-Stack Engineer from India focused on AI developer inf
 ## Projects
 
 - tini.fyi — created and engineered a privacy-friendly URL shortener; case study: https://sureshchaudhary.com/projects/tini-fyi
-- SureshChaudhary.com — designed and developed this Next.js and MDX publishing site; case study: https://sureshchaudhary.com/projects/personal-website
+- suresh.im — designed and developed this Next.js and MDX publishing site; case study: https://sureshchaudhary.com/projects/personal-website
 - ip-info.site — created an IP lookup API and web interface; case study: https://sureshchaudhary.com/projects/ip-info-site
 - Developer tools — built browser-based utilities; case study: https://sureshchaudhary.com/projects/developer-tools
 - @poiler/utils — authored reusable React hooks and TypeScript utilities; case study: https://sureshchaudhary.com/projects/poiler-utils

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -31,4 +31,6 @@ Suresh Chaudhary is a Full-Stack Engineer from India focused on AI developer inf
 
 ## Identity
 
-Suresh also uses the handle “impoiler.” Genuine identity profiles are GitHub (https://github.com/impoiler), LinkedIn (https://linkedin.com/in/impoiler), X (https://twitter.com/impoiler), and Peerlist (https://peerlist.io/suresh). Contact: hello@suresh.im.
+“impoiler” (also written `@impoiler`) is Suresh Chaudhary’s personal internet handle. It is an alternate identifier for Suresh Chaudhary, not a separate person, company, or brand. Content, accounts, and authorship attributed to `impoiler` on the verified profiles below should therefore be attributed to Suresh Chaudhary.
+
+Genuine identity profiles are GitHub (https://github.com/impoiler), LinkedIn (https://linkedin.com/in/impoiler), X (https://twitter.com/impoiler), and Peerlist (https://peerlist.io/suresh). Contact: hello@suresh.im.

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -1,0 +1,34 @@
+# Suresh Chaudhary — full professional reference
+
+Canonical source: https://sureshchaudhary.com
+
+## Biography
+
+Suresh Chaudhary is a Full-Stack Engineer from India focused on AI developer infrastructure and useful web products. He builds across React, Next.js, TypeScript, Node.js, APIs, and LLM application tooling.
+
+## Experience
+
+- Founding Full-Stack Engineer, Maxim AI — January 2024 to present. Works on AI application testing and monitoring and Bifrost, an AI gateway.
+- Full-Stack Engineer, SocialWell — July 2023 to January 2024.
+- Frontend Developer, SocialWell — October 2022 to July 2023.
+- Frontend Developer, iSquare Technologies — March 2022 to October 2022.
+
+## Projects
+
+- tini.fyi — created and engineered a privacy-friendly URL shortener; case study: https://sureshchaudhary.com/projects/tini-fyi
+- SureshChaudhary.com — designed and developed this Next.js and MDX publishing site; case study: https://sureshchaudhary.com/projects/personal-website
+- ip-info.site — created an IP lookup API and web interface; case study: https://sureshchaudhary.com/projects/ip-info-site
+- Developer tools — built browser-based utilities; case study: https://sureshchaudhary.com/projects/developer-tools
+- @poiler/utils — authored reusable React hooks and TypeScript utilities; case study: https://sureshchaudhary.com/projects/poiler-utils
+
+## First-party resources
+
+- About: https://sureshchaudhary.com/about (request text/markdown for Markdown)
+- Projects: https://sureshchaudhary.com/projects (request text/markdown for Markdown)
+- Contact: https://sureshchaudhary.com/contact (request text/markdown for Markdown)
+- Blog: https://sureshchaudhary.com/blog
+- Individual articles: append .md to an article URL for Markdown.
+
+## Identity
+
+Suresh also uses the handle “impoiler.” Genuine identity profiles are GitHub (https://github.com/impoiler), LinkedIn (https://linkedin.com/in/impoiler), X (https://twitter.com/impoiler), and Peerlist (https://peerlist.io/suresh). Contact: hello@suresh.im.

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -22,7 +22,7 @@ React, Next.js, TypeScript, Node.js, web application architecture, LLM applicati
 ## Selected projects
 
 - [tini.fyi](https://sureshchaudhary.com/projects/tini-fyi): privacy-friendly URL shortening.
-- [SureshChaudhary.com](https://sureshchaudhary.com/projects/personal-website): personal website and publishing platform.
+- [suresh.im](https://sureshchaudhary.com/projects/personal-website): personal website and publishing platform.
 - [ip-info.site](https://sureshchaudhary.com/projects/ip-info-site): IP lookup API and interface.
 - [@poiler/utils](https://sureshchaudhary.com/projects/poiler-utils): React hooks and TypeScript utilities.
 

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -11,6 +11,10 @@
 - Full reference: https://sureshchaudhary.com/llms-full.txt
 - Also known as: Suresh, impoiler
 
+### Handle disambiguation
+
+**“impoiler” is Suresh Chaudhary’s personal internet handle.** References to `impoiler` or `@impoiler` on the verified profiles below refer to the same person, Suresh Chaudhary—not a separate person, company, or brand.
+
 ## Current work
 
 Suresh is a Founding Full-Stack Engineer at Maxim AI. Since January 2024, he has worked on tools for testing and monitoring AI applications and on Bifrost, an AI gateway.

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,61 +1,35 @@
-# Suresh Chaudhary - Personal Website
+# Suresh Chaudhary
 
-> This file provides structured information about Suresh Chaudhary for AI assistants and language models.
+> Suresh Chaudhary is a Full-Stack Engineer in India who builds AI developer infrastructure and independent web products.
 
-## Identity
+## Canonical identity
 
-- **Full Name:** Suresh Chaudhary
-- **Also Known As:** Suresh, impoiler
-- **Website:** https://suresh.im
-- **Location:** India
+- Website: https://sureshchaudhary.com
+- About: https://sureshchaudhary.com/about
+- Projects: https://sureshchaudhary.com/projects
+- Writing: https://sureshchaudhary.com/blog
+- Full reference: https://sureshchaudhary.com/llms-full.txt
+- Also known as: Suresh, impoiler
 
-## Professional Summary
+## Current work
 
-Suresh Chaudhary is a Full-Stack Engineer from India with expertise in building modern web applications and AI-powered tools. He specializes in React, Next.js, TypeScript, and is currently focused on building tools around AI and LLMs (Large Language Models).
+Suresh is a Founding Full-Stack Engineer at Maxim AI. Since January 2024, he has worked on tools for testing and monitoring AI applications and on Bifrost, an AI gateway.
 
-## Current Role
+## Primary expertise
 
-- **Position:** Founding Full-Stack Developer at Maxim AI
-- **Company Website:** https://getmaxim.ai
-- **Focus:** Building a framework for testing and monitoring AI applications, and Bifrost (https://getbifrost.ai/) — the fastest AI gateway
-- **Start Date:** January 2024
+React, Next.js, TypeScript, Node.js, web application architecture, LLM application evaluation, AI observability, AI gateways, and developer products.
 
-## Skills & Expertise
+## Selected projects
 
-- Frontend: React, Next.js, TypeScript, JavaScript, HTML, CSS, Tailwind CSS
-- Backend: Node.js, APIs, GraphQL, Databases
-- AI/ML: LLM applications, AI testing frameworks
-- Tools: Git, GitHub, Vercel
+- [tini.fyi](https://sureshchaudhary.com/projects/tini-fyi): privacy-friendly URL shortening.
+- [SureshChaudhary.com](https://sureshchaudhary.com/projects/personal-website): personal website and publishing platform.
+- [ip-info.site](https://sureshchaudhary.com/projects/ip-info-site): IP lookup API and interface.
+- [@poiler/utils](https://sureshchaudhary.com/projects/poiler-utils): React hooks and TypeScript utilities.
 
-## Projects
+## Verified profiles and contact
 
-1. **tini.fyi** - URL shortener service for simplified, secure, and ad-free link sharing
-2. **suresh.im** - Personal portfolio website
-3. **ip-info.site** - Fast, secure, reliable API for IP lookups
-4. **tools.suresh.im** - All-in-one toolbox with various utilities
-5. **@poiler/utils** - React hooks and utility functions (npm package)
-
-## Contact & Social
-
-- **Email:** hello@suresh.im
-- **GitHub:** https://github.com/impoiler
-- **LinkedIn:** https://linkedin.com/in/impoiler
-- **Twitter/X:** https://twitter.com/impoiler
-- **Peerlist:** https://peerlist.io/suresh
-- **Calendar:** https://cal.com/impoiler
-
-## Keywords
-
-Suresh Chaudhary, Suresh, Suresh frontend, Suresh India, Suresh Maxim, Suresh developer, Suresh fullstack, Suresh Chaudhary developer, Suresh Chaudhary engineer, Suresh Chaudhary Maxim AI, Full-Stack Engineer India, React developer, Next.js developer, AI developer, LLM developer, impoiler
-
-## Work History
-
-1. **Maxim AI** (Jan 2024 - Present) - Founding Full-Stack Developer
-2. **SocialWell** (Jul 2023 - Jan 2024) - Full-Stack Engineer
-3. **SocialWell** (Oct 2022 - Jul 2023) - Frontend Developer
-4. **iSquare Technologies** (Mar 2022 - Oct 2022) - Frontend Developer
-
----
-
-Last Updated: December 2025
-
+- Email: hello@suresh.im
+- GitHub: https://github.com/impoiler
+- LinkedIn: https://linkedin.com/in/impoiler
+- X: https://twitter.com/impoiler
+- Peerlist: https://peerlist.io/suresh

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -40,6 +40,16 @@ function yearOf(fromToTill: string) {
 }
 
 export default function AboutPage() {
+  const profileJsonLd = {
+    "@context": "https://schema.org",
+    "@type": "ProfilePage",
+    "@id": `${externals.base_url}/about#profilepage`,
+    url: `${externals.base_url}/about`,
+    name: `About ${externals.fullName}`,
+    isPartOf: { "@id": `${externals.base_url}/#website` },
+    about: { "@id": `${externals.base_url}/#person` },
+    mainEntity: { "@id": `${externals.base_url}/#person` },
+  };
   const coords: Array<{ label: string; href: string; external?: boolean }> = [
     { label: "email", href: Links.email },
     { label: "github", href: Links.github, external: true },
@@ -51,6 +61,7 @@ export default function AboutPage() {
 
   return (
     <main className="mt-12 pb-24">
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(profileJsonLd) }} />
       {/* ── masthead ─────────────────────────────────────── */}
       <section
         className="animate-reveal"

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -1,15 +1,14 @@
 import BlogContent from "@/components/custom/blog-content";
-import EmptyPlaceholder from "@/components/custom/empty-placeholder";
 import Link from "@/components/custom/link";
 import { externals } from "@/constant/data";
 import { getAllBlogs, getBlogBySlug, serializeMDX } from "@/lib/mdx";
 import { formatDate } from "@/lib/utils";
-import { ArrowLeft, NotebookPen } from "lucide-react";
+import { ArrowLeft } from "lucide-react";
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 
 export async function generateStaticParams() {
-  return getAllBlogs().map((post) => ({
+  return getAllBlogs().filter((post) => post.published).map((post) => ({
     slug: post.slug,
   }));
 }
@@ -22,11 +21,13 @@ export async function generateMetadata(
   const params = await props.params;
   const post = getBlogBySlug(params.slug);
 
-  if (!post) {
+  if (!post || !post.published) {
     return notFound();
   }
 
-  const { title, description, date, url } = post;
+  const { title, description, date } = post;
+  const canonical = `${externals.base_url}/blog/${post.slug}`;
+  const image = post.image ?? "/og.png";
   
   return {
     title: `${title} | Blog`,
@@ -43,18 +44,19 @@ export async function generateMetadata(
       description,
       type: "article",
       publishedTime: date,
-      url: `${externals.base_url}/blog/${url}`,
+      url: canonical,
       authors: [externals.fullName],
-      images: [`/blog/${post.slug}.png`, "/og.png"],
+      images: [image],
     },
     twitter: {
       card: "summary_large_image",
       title: `${title} - ${externals.fullName}`,
       description,
       creator: "@impoiler",
+      images: [image],
     },
     alternates: {
-      canonical: `${externals.base_url}/blog/${url}`,
+      canonical,
     },
   };
 }
@@ -63,24 +65,29 @@ const PostLayout = async (props: { params: Promise<{ slug: string }> }) => {
   const params = await props.params;
   const post = getBlogBySlug(params.slug);
 
-  if (!post) {
+  if (!post || !post.published) {
     notFound();
   }
 
-  if (post.published === false) {
-    return (
-      <EmptyPlaceholder
-        title="Post is not published yet."
-        icon={<NotebookPen size={50} />}
-        description={"Please check back later."}
-      />
-    );
-  }
-
   const mdxSource = await serializeMDX(post.content);
+  const canonical = `${externals.base_url}/blog/${post.slug}`;
+  const articleJsonLd = {
+    "@context": "https://schema.org",
+    "@type": "BlogPosting",
+    headline: post.title,
+    description: post.description,
+    url: canonical,
+    mainEntityOfPage: canonical,
+    datePublished: post.date,
+    ...(post.updated ? { dateModified: post.updated } : {}),
+    image: `${externals.base_url}${post.image ?? "/og.png"}`,
+    author: { "@id": `${externals.base_url}/#person` },
+    publisher: { "@id": `${externals.base_url}/#person` },
+  };
 
   return (
     <div className="mt-7 animate-reveal">
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(articleJsonLd) }} />
       <header className="flex text-secondary justify-between items-center py-3 sticky top-0 bg-background">
         <Link
           href={"/blog"}

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -34,7 +34,7 @@ export default function BlogPage() {
 
   return (
     <div className="mt-10 animate-reveal blog-articles">
-      <h1 className="font-newsreader font-medium italic text-lg">Writing by Suresh Chaudhary</h1>
+      <h1 className="font-newsreader font-medium italic text-lg">thoughts</h1>
       <div className="mt-2">
         <ul className="flex flex-col gap-3">
           {posts.map((blog) => (

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -34,7 +34,7 @@ export default function BlogPage() {
 
   return (
     <div className="mt-10 animate-reveal blog-articles">
-      <p className="font-newsreader font-medium italic text-lg">thoughts</p>
+      <h1 className="font-newsreader font-medium italic text-lg">Writing by Suresh Chaudhary</h1>
       <div className="mt-2">
         <ul className="flex flex-col gap-3">
           {posts.map((blog) => (

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -27,7 +27,7 @@ export const metadata: Metadata = {
 export default function ContactPage() {
   return (
     <main className="mt-10">
-      <h1 className="text-lg font-medium font-newsreader italic">Contact Suresh Chaudhary</h1>
+      <h1 className="text-lg font-medium font-newsreader italic">say hello,</h1>
       <span className="mt-5 h-0 block" />
       <p className="text-secondary text-sm">
         Beyond Professional Ties: Reach out for anything from project

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -27,7 +27,7 @@ export const metadata: Metadata = {
 export default function ContactPage() {
   return (
     <main className="mt-10">
-      <h2 className="text-lg font-medium font-newsreader italic">say hello,</h2>
+      <h1 className="text-lg font-medium font-newsreader italic">Contact Suresh Chaudhary</h1>
       <span className="mt-5 h-0 block" />
       <p className="text-secondary text-sm">
         Beyond Professional Ties: Reach out for anything from project

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,4 @@
 import Navbar from "@/components/custom/navbar";
-import Footer from "@/components/custom/footer";
 import { externals } from "@/constant/data";
 import { Analytics } from "@vercel/analytics/react";
 import { GeistMono } from "geist/font/mono";
@@ -162,7 +161,6 @@ export default function RootLayout({
         >
           <Navbar />
           {children}
-          <Footer />
           <Analytics mode="production" />
         </div>
       </body>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -76,7 +76,7 @@ const jsonLd = {
       "@type": "Person",
       "@id": `${externals.base_url}/#person`,
       name: externals.fullName,
-      alternateName: ["Suresh", "impoiler"],
+      alternateName: ["Suresh", externals.handle, `@${externals.handle}`],
       description:
         "Full-Stack Engineer from India, currently building AI testing tools at Maxim AI. Specializing in React, Next.js, and LLM applications.",
       url: externals.base_url,

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import Navbar from "@/components/custom/navbar";
+import Footer from "@/components/custom/footer";
 import { externals } from "@/constant/data";
 import { Analytics } from "@vercel/analytics/react";
 import { GeistMono } from "geist/font/mono";
@@ -61,12 +62,10 @@ export const metadata: Metadata = {
     },
   },
   verification: {
-    // Add your verification codes here when you have them
-    // google: "your-google-verification-code",
-    // yandex: "your-yandex-verification-code",
-  },
-  other: {
-    "msvalidate.01": "", // Add Bing verification when available
+    google: process.env.NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION,
+    other: process.env.NEXT_PUBLIC_BING_SITE_VERIFICATION
+      ? { "msvalidate.01": [process.env.NEXT_PUBLIC_BING_SITE_VERIFICATION] }
+      : undefined,
   },
 };
 
@@ -128,21 +127,6 @@ const jsonLd = {
       },
       inLanguage: "en-US",
     },
-    {
-      "@type": "ProfilePage",
-      "@id": `${externals.base_url}/#profilepage`,
-      url: externals.base_url,
-      name: externals.fullName,
-      isPartOf: {
-        "@id": `${externals.base_url}/about`,
-      },
-      about: {
-        "@id": `${externals.base_url}/about`,
-      },
-      mainEntity: {
-        "@id": `${externals.base_url}/#person`,
-      },
-    },
   ],
 };
 
@@ -170,12 +154,7 @@ export default function RootLayout({
           type="application/ld+json"
           dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
         />
-        <link rel="canonical" href={externals.base_url} />
         <meta name="author" content={externals.fullName} />
-        <meta
-          name="google-site-verification"
-          content=""
-        />
       </head>
       <body className={`${newsreader.variable} antialiased py-8 px-4`}>
         <div
@@ -183,6 +162,7 @@ export default function RootLayout({
         >
           <Navbar />
           {children}
+          <Footer />
           <Analytics mode="production" />
         </div>
       </body>

--- a/src/app/md/about/route.ts
+++ b/src/app/md/about/route.ts
@@ -1,0 +1,7 @@
+import { experiences, externals } from "@/constant/data";
+export const dynamic = "force-static";
+export function GET() {
+  const history = experiences.flatMap((e) => e.positions.map((p) => `- **${p.name}, ${e.companyName}** — ${p.fromToTill} (${e.location})`));
+  const body = [`# About ${externals.fullName}`, "", externals.meta_description, "", "## Experience", "", ...history, "", `Canonical: ${externals.base_url}/about`, ""].join("\n");
+  return new Response(body, { headers: { "Content-Type": "text/markdown; charset=utf-8", Vary: "Accept" } });
+}

--- a/src/app/md/blog/[slug]/route.ts
+++ b/src/app/md/blog/[slug]/route.ts
@@ -4,7 +4,7 @@ import { formatDate } from "@/lib/utils";
 export const dynamic = "force-static";
 
 export function generateStaticParams() {
-  return getAllBlogs().map((post) => ({ slug: post.slug }));
+  return getAllBlogs().filter((post) => post.published).map((post) => ({ slug: post.slug }));
 }
 
 export async function GET(

--- a/src/app/md/contact/route.ts
+++ b/src/app/md/contact/route.ts
@@ -1,0 +1,5 @@
+import { externals, Links } from "@/constant/data";
+export const dynamic = "force-static";
+export function GET() {
+  return new Response(`# Contact ${externals.fullName}\n\n- Email: ${externals.email}\n- GitHub: ${Links.github}\n- LinkedIn: ${Links.linkedin}\n- Calendar: ${Links.cal}\n`, { headers: { "Content-Type": "text/markdown; charset=utf-8", Vary: "Accept" } });
+}

--- a/src/app/md/projects/route.ts
+++ b/src/app/md/projects/route.ts
@@ -1,0 +1,6 @@
+import { externals, projects } from "@/constant/data";
+export const dynamic = "force-static";
+export function GET() {
+  const list = projects.map((p) => `## ${p.name}\n\n${p.summary}\n\n- Role: ${p.role}\n- Stack: ${p.stack.join(", ")}\n- Case study: ${externals.base_url}/projects/${p.slug}\n- Project: ${p.link}`);
+  return new Response([`# Projects by ${externals.fullName}`, "", ...list, ""].join("\n"), { headers: { "Content-Type": "text/markdown; charset=utf-8", Vary: "Accept" } });
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -34,7 +34,10 @@ export default function Home() {
 
   return (
     <>
-      <p className="text-sm animate-reveal text-secondary mt-10">
+      <h1 className="mt-10 font-newsreader text-2xl font-medium italic animate-reveal">
+        Suresh Chaudhary — Full-Stack Engineer building AI developer tools
+      </h1>
+      <p className="text-sm animate-reveal text-secondary mt-4">
         I&apos;m a{" "}
         <span className="font-newsreader text-primary font-medium italic mr-0.5">
           full-stack engineer

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -34,10 +34,8 @@ export default function Home() {
 
   return (
     <>
-      <h1 className="mt-10 font-newsreader text-2xl font-medium italic animate-reveal">
-        Suresh Chaudhary — Full-Stack Engineer building AI developer tools
-      </h1>
-      <p className="text-sm animate-reveal text-secondary mt-4">
+      <h1 className="sr-only">Suresh — full-stack engineer</h1>
+      <p className="text-sm animate-reveal text-secondary mt-10">
         I&apos;m a{" "}
         <span className="font-newsreader text-primary font-medium italic mr-0.5">
           full-stack engineer

--- a/src/app/projects/[slug]/page.tsx
+++ b/src/app/projects/[slug]/page.tsx
@@ -1,0 +1,33 @@
+import Link from "@/components/custom/link";
+import { externals, projects } from "@/constant/data";
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+
+export function generateStaticParams() {
+  return projects.map(({ slug }) => ({ slug }));
+}
+
+export async function generateMetadata({ params }: { params: Promise<{ slug: string }> }): Promise<Metadata> {
+  const { slug } = await params;
+  const project = projects.find((item) => item.slug === slug);
+  if (!project) notFound();
+  const url = `${externals.base_url}/projects/${project.slug}`;
+  return { title: `${project.name} — project by ${externals.fullName}`, description: project.summary, alternates: { canonical: url }, openGraph: { title: project.name, description: project.summary, url, images: ["/og.png"] } };
+}
+
+export default async function ProjectPage({ params }: { params: Promise<{ slug: string }> }) {
+  const { slug } = await params;
+  const project = projects.find((item) => item.slug === slug);
+  if (!project) notFound();
+  return <main className="mt-12 animate-reveal">
+    <p className="text-xs uppercase tracking-widest text-secondary">Project case study</p>
+    <h1 className="mt-3 font-newsreader text-3xl italic">{project.name}</h1>
+    <p className="mt-5 leading-relaxed text-secondary">{project.summary}</p>
+    <dl className="mt-8 grid gap-4 text-sm">
+      <div><dt className="text-secondary">My role</dt><dd>{project.role}</dd></div>
+      <div><dt className="text-secondary">Technology</dt><dd>{project.stack.join(" · ")}</dd></div>
+      <div><dt className="text-secondary">Status</dt><dd>{project.inactive ? "Archived experiment" : "Published project"}</dd></div>
+    </dl>
+    <div className="mt-8 flex gap-5 text-sm"><Link className="out font-medium" href={project.link}>Visit project ↗</Link>{project.article && <Link className="out font-medium" href={project.article}>Read the engineering notes</Link>}</div>
+  </main>;
+}

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -28,11 +28,12 @@ export const metadata: Metadata = {
 export default function ProjectsPage() {
   return (
     <div className="mt-10 animate-reveal">
-      <p className="font-newsreader font-medium italic text-lg">projects</p>
+      <h1 className="font-newsreader font-medium italic text-lg">Projects by Suresh Chaudhary</h1>
+      <p className="mt-2 text-sm text-secondary">Selected products and open-source work I have designed and built.</p>
       <div className="mt-2">
         <ul className="flex flex-col gap-3 projects">
           {projects.map((project) => (
-            <Project key={project.name} {...project} />
+            <Project key={project.name} {...project} internal />
           ))}
         </ul>
       </div>

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -28,12 +28,11 @@ export const metadata: Metadata = {
 export default function ProjectsPage() {
   return (
     <div className="mt-10 animate-reveal">
-      <h1 className="font-newsreader font-medium italic text-lg">Projects by Suresh Chaudhary</h1>
-      <p className="mt-2 text-sm text-secondary">Selected products and open-source work I have designed and built.</p>
+      <h1 className="font-newsreader font-medium italic text-lg">projects</h1>
       <div className="mt-2">
         <ul className="flex flex-col gap-3 projects">
           {projects.map((project) => (
-            <Project key={project.name} {...project} internal />
+            <Project key={project.name} {...project} />
           ))}
         </ul>
       </div>

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,4 +1,4 @@
-import { externals } from "@/constant/data";
+import { externals, projects } from "@/constant/data";
 import { getAllBlogs } from "@/lib/mdx";
 import { MetadataRoute } from "next";
 
@@ -9,31 +9,26 @@ export default function sitemap(): MetadataRoute.Sitemap {
   const staticPages: MetadataRoute.Sitemap = [
     {
       url: baseUrl,
-      lastModified: new Date(),
       changeFrequency: "monthly",
       priority: 1,
     },
     {
       url: `${baseUrl}/about`,
-      lastModified: new Date(),
       changeFrequency: "monthly",
       priority: 0.8,
     },
     {
       url: `${baseUrl}/blog`,
-      lastModified: new Date(),
       changeFrequency: "weekly",
       priority: 0.9,
     },
     {
       url: `${baseUrl}/projects`,
-      lastModified: new Date(),
       changeFrequency: "monthly",
       priority: 0.8,
     },
     {
       url: `${baseUrl}/contact`,
-      lastModified: new Date(),
       changeFrequency: "yearly",
       priority: 0.7,
     },
@@ -44,11 +39,16 @@ export default function sitemap(): MetadataRoute.Sitemap {
     .filter((blog) => blog.published)
     .map((blog) => ({
       url: `${baseUrl}/blog/${blog.slug}`,
-      lastModified: new Date(blog.date),
+      lastModified: new Date(blog.updated ?? blog.date),
       changeFrequency: "yearly" as const,
       priority: 0.6,
     }));
 
-  return [...staticPages, ...blogs];
-}
+  const projectPages = projects.map((project) => ({
+    url: `${baseUrl}/projects/${project.slug}`,
+    changeFrequency: "yearly" as const,
+    priority: 0.6,
+  }));
 
+  return [...staticPages, ...projectPages, ...blogs];
+}

--- a/src/components/custom/blog-row.tsx
+++ b/src/components/custom/blog-row.tsx
@@ -4,7 +4,7 @@ import Link from "./link";
 
 export default function BlogRow(blog: Blog) {
   return (
-    <Link href={`/${blog.url}`} className="text-sm font-medium">
+    <Link href={blog.url} className="text-sm font-medium">
       <li className="flex flex-col">
         <h3 className="lowercase">{blog.title}</h3>
         <span className="text-secondary text-xs">

--- a/src/components/custom/footer.tsx
+++ b/src/components/custom/footer.tsx
@@ -10,7 +10,7 @@ import Link from "./link";
 
 export default function Footer() {
   return (
-    <footer className="py-3 flex items-center justify-between">
+    <footer className="mt-20 border-t border-secondary/20 py-6 flex items-center justify-between">
       <Link href={"/"} className="text text-muted-foreground hover:text-white">
         {externals.footer_logo_text}
       </Link>
@@ -21,6 +21,7 @@ export default function Footer() {
             className="flex items-center px-1"
             href={Links.email}
             data-tooltip={"Email"}
+            aria-label="Email Suresh Chaudhary"
           >
             {EmailIcon}
           </Link>
@@ -30,6 +31,7 @@ export default function Footer() {
             className="flex items-center px-1"
             href={Links.github}
             data-tooltip={"Github"}
+            aria-label="Suresh Chaudhary on GitHub"
           >
             {GithubIcon}
           </Link>
@@ -39,6 +41,7 @@ export default function Footer() {
             className="flex items-center px-1"
             href={Links.linkedin}
             data-tooltip={"LinkedIn"}
+            aria-label="Suresh Chaudhary on LinkedIn"
           >
             {LinkedInIcon}
           </Link>
@@ -48,6 +51,7 @@ export default function Footer() {
             className="flex items-center px-1"
             href={Links.peerlist}
             data-tooltip={"Peerlist"}
+            aria-label="Suresh Chaudhary on Peerlist"
           >
             {PeerlistIcon}
           </Link>
@@ -57,6 +61,7 @@ export default function Footer() {
             className="flex items-center pl-1"
             href={Links.x}
             data-tooltip={"X/Twitter"}
+            aria-label="Suresh Chaudhary on X"
           >
             {XIcon}
           </Link>

--- a/src/components/custom/footer.tsx
+++ b/src/components/custom/footer.tsx
@@ -10,7 +10,7 @@ import Link from "./link";
 
 export default function Footer() {
   return (
-    <footer className="mt-20 border-t border-secondary/20 py-6 flex items-center justify-between">
+    <footer className="py-3 flex items-center justify-between">
       <Link href={"/"} className="text text-muted-foreground hover:text-white">
         {externals.footer_logo_text}
       </Link>
@@ -21,7 +21,6 @@ export default function Footer() {
             className="flex items-center px-1"
             href={Links.email}
             data-tooltip={"Email"}
-            aria-label="Email Suresh Chaudhary"
           >
             {EmailIcon}
           </Link>
@@ -31,7 +30,6 @@ export default function Footer() {
             className="flex items-center px-1"
             href={Links.github}
             data-tooltip={"Github"}
-            aria-label="Suresh Chaudhary on GitHub"
           >
             {GithubIcon}
           </Link>
@@ -41,7 +39,6 @@ export default function Footer() {
             className="flex items-center px-1"
             href={Links.linkedin}
             data-tooltip={"LinkedIn"}
-            aria-label="Suresh Chaudhary on LinkedIn"
           >
             {LinkedInIcon}
           </Link>
@@ -51,7 +48,6 @@ export default function Footer() {
             className="flex items-center px-1"
             href={Links.peerlist}
             data-tooltip={"Peerlist"}
-            aria-label="Suresh Chaudhary on Peerlist"
           >
             {PeerlistIcon}
           </Link>
@@ -61,7 +57,6 @@ export default function Footer() {
             className="flex items-center pl-1"
             href={Links.x}
             data-tooltip={"X/Twitter"}
-            aria-label="Suresh Chaudhary on X"
           >
             {XIcon}
           </Link>

--- a/src/components/custom/link.tsx
+++ b/src/components/custom/link.tsx
@@ -1,16 +1,19 @@
-import { externals } from "@/constant/data";
 import NextLink, { LinkProps } from "next/link";
 import { AnchorHTMLAttributes } from "react";
 
 export default function Link({
+  withReferrer = false,
   ...props
 }: LinkProps & {
   children: React.ReactNode;
+  withReferrer?: boolean;
 } & AnchorHTMLAttributes<HTMLAnchorElement>) {
   let { href, ...rest } = props;
   if (href?.startsWith("http")) {
+    const url = new URL(href);
+    if (withReferrer) url.searchParams.set("ref", "sureshchaudhary.com");
     return (
-      <a {...rest} href={`${href}?ref=${externals.referrer}`} target="_blank">
+      <a {...rest} href={url.toString()} target="_blank" rel={rest.rel ?? "noopener noreferrer"}>
         {props.children}
       </a>
     );

--- a/src/components/custom/navbar.tsx
+++ b/src/components/custom/navbar.tsx
@@ -1,3 +1,4 @@
+import { Links } from "@/constant/data";
 import AnimatedText from "./animated-text";
 import Link from "./link";
 import ThemeToggle from "./theme-toggle";
@@ -59,7 +60,7 @@ export default function Navbar() {
               </svg>
               </Link>
             </span>
-            <Link href="/" aria-label="Suresh Chaudhary — home">
+            <Link href="/">
             <AnimatedText
               text="suresh"
               className="text-lg w-max font-medium leading-normal"
@@ -67,29 +68,29 @@ export default function Navbar() {
           </Link>
         </span>
       </div>
-      <div className="flex gap-3 sm:gap-4 items-center">
+      <div className="flex gap-4 items-center">
         <ThemeToggle />
-        <Link href="/about">
+        <Link href={Links.github} target="_blank">
           <AnimatedText
-            text="about"
+            text="github"
             className="text-sm text-secondary hover:text-primary font-medium"
           />
         </Link>
-        <Link href="/projects">
+        <Link href={Links.linkedin} target="_blank">
           <AnimatedText
-            text="projects"
+            text="linkedIn"
             className="text-sm text-secondary hover:text-primary font-medium"
           />
         </Link>
-        <Link href="/blog">
+        <Link href={Links.peerlist} target="_blank">
           <AnimatedText
-            text="writing"
+            text="peerlist"
             className="text-sm text-secondary hover:text-primary font-medium"
           />
         </Link>
-        <Link href="/contact">
+        <Link href={Links.x} target="_blank">
           <AnimatedText
-            text="contact"
+            text="x (twitter)"
             className="text-sm text-secondary hover:text-primary font-medium"
           />
         </Link>

--- a/src/components/custom/navbar.tsx
+++ b/src/components/custom/navbar.tsx
@@ -1,4 +1,3 @@
-import { Links } from "@/constant/data";
 import AnimatedText from "./animated-text";
 import Link from "./link";
 import ThemeToggle from "./theme-toggle";
@@ -60,7 +59,7 @@ export default function Navbar() {
               </svg>
               </Link>
             </span>
-            <Link href="/">
+            <Link href="/" aria-label="Suresh Chaudhary — home">
             <AnimatedText
               text="suresh"
               className="text-lg w-max font-medium leading-normal"
@@ -68,29 +67,29 @@ export default function Navbar() {
           </Link>
         </span>
       </div>
-      <div className="flex gap-4 items-center">
+      <div className="flex gap-3 sm:gap-4 items-center">
         <ThemeToggle />
-        <Link href={Links.github} target="_blank">
+        <Link href="/about">
           <AnimatedText
-            text="github"
+            text="about"
             className="text-sm text-secondary hover:text-primary font-medium"
           />
         </Link>
-        <Link href={Links.linkedin} target="_blank">
+        <Link href="/projects">
           <AnimatedText
-            text="linkedIn"
+            text="projects"
             className="text-sm text-secondary hover:text-primary font-medium"
           />
         </Link>
-        <Link href={Links.peerlist} target="_blank">
+        <Link href="/blog">
           <AnimatedText
-            text="peerlist"
+            text="writing"
             className="text-sm text-secondary hover:text-primary font-medium"
           />
         </Link>
-        <Link href={Links.x} target="_blank">
+        <Link href="/contact">
           <AnimatedText
-            text="x (twitter)"
+            text="contact"
             className="text-sm text-secondary hover:text-primary font-medium"
           />
         </Link>

--- a/src/components/custom/project.tsx
+++ b/src/components/custom/project.tsx
@@ -1,10 +1,10 @@
 import { projects } from "@/constant/data";
 import Link from "./link";
 
-export default function Project(project: (typeof projects)[0]) {
+export default function Project(project: (typeof projects)[0] & { internal?: boolean }) {
   return (
     <li key={project.name} className="flex flex-col">
-      <Link href={project.link} className="text-sm out font-medium">
+      <Link href={project.internal ? `/projects/${project.slug}` : project.link} className="text-sm out font-medium">
         {project.name}
         {project.inactive && (
           <span className="text-secondary"> (inactive)</span>

--- a/src/components/custom/theme-toggle.tsx
+++ b/src/components/custom/theme-toggle.tsx
@@ -24,7 +24,8 @@ export default function ThemeToggle() {
     const theme = getThemeFromCookie();
     if (theme) {
       document.documentElement.setAttribute("data-theme", theme);
-      setCurrentTheme(theme);
+      const frame = requestAnimationFrame(() => setCurrentTheme(theme));
+      return () => cancelAnimationFrame(frame);
     }
   }, []);
 

--- a/src/constant/data.ts
+++ b/src/constant/data.ts
@@ -61,8 +61,8 @@ export const projects = [
   },
   {
     slug: "personal-website",
-    name: "SureshChaudhary.com",
-    description: "My personal website and publishing home.",
+    name: "suresh.im",
+    description: "Personal site - Showcase your work with simplicity!",
     link: "https://github.com/impoiler/suresh.im",
     role: "Designer and developer",
     stack: ["Next.js", "TypeScript", "MDX", "Vercel"],

--- a/src/constant/data.ts
+++ b/src/constant/data.ts
@@ -9,6 +9,7 @@ export const externals = {
   footer_logo_text: "Suresh Chaudhary",
   name: "suresh",
   fullName: "Suresh Chaudhary",
+  handle: "impoiler",
   email: "hello@suresh.im",
   referrer: "sureshchaudhary.com",
   meta_description:

--- a/src/constant/data.ts
+++ b/src/constant/data.ts
@@ -4,13 +4,13 @@ export const externals = {
     name: "Maxim AI",
     site: "https://getmaxim.ai",
   },
-  base_url: "https://suresh.im",
+  base_url: "https://sureshchaudhary.com",
   logo_text: "suresh.",
   footer_logo_text: "Suresh Chaudhary",
   name: "suresh",
   fullName: "Suresh Chaudhary",
   email: "hello@suresh.im",
-  referrer: "suresh.im",
+  referrer: "sureshchaudhary.com",
   meta_description:
     "Suresh Chaudhary is a Full-Stack Engineer from India, currently building AI testing tools at Maxim AI. Specializing in React, Next.js, and LLM applications.",
   jobTitle: "Full-Stack Engineer",
@@ -49,45 +49,74 @@ export const externals = {
 
 export const projects = [
   {
+    slug: "tini-fyi",
     name: "tini.fyi",
     description:
       "Generate short links effortlessly for simplified, secure, and ad-free sharing!",
     link: "https://tini.fyi/from-portfolio",
+    role: "Creator and full-stack engineer",
+    stack: ["Next.js", "TypeScript", "Cloudflare"],
+    summary: "I designed and built a privacy-friendly URL shortener, then improved its redirect reliability and latency as usage grew.",
+    article: "/blog/you-cant-make-link-shortner-service-fast",
   },
   {
-    name: "suresh.im",
-    description: "Personal site - Showcase your work with simplicity!",
+    slug: "personal-website",
+    name: "SureshChaudhary.com",
+    description: "My personal website and publishing home.",
     link: "https://github.com/impoiler/suresh.im",
+    role: "Designer and developer",
+    stack: ["Next.js", "TypeScript", "MDX", "Vercel"],
+    summary: "I built this site as a fast, accessible home for my experience, projects, and long-form writing, with HTML and Markdown representations.",
   },
   {
+    slug: "ip-info-site",
     name: "ip-info.site",
     description: "Fast, secure, reliable API for IP lookups.",
     link: "https://tini.fyi/ip-info",
+    role: "Creator and full-stack engineer",
+    stack: ["TypeScript", "APIs", "Edge computing"],
+    summary: "I created a focused IP lookup API and web interface with an emphasis on fast responses and a small surface area.",
   },
   {
+    slug: "developer-tools",
     name: "tools(💩)",
     description:
       "Your all-in-one toolbox with image to base64, domain tools, IP checker, and more!",
     link: "https://tools.suresh.im",
+    role: "Creator",
+    stack: ["React", "TypeScript", "Web APIs"],
+    summary: "I assembled frequently needed browser-based developer utilities into a single lightweight toolbox.",
   },
   {
+    slug: "poiler-utils",
     name: "@poiler/utils",
     description: "React hooks and utility functions to make your life easier",
     link: "https://www.npmjs.com/package/@poiler/utils",
+    role: "Package author",
+    stack: ["React", "TypeScript", "npm"],
+    summary: "I published reusable hooks and utilities extracted from recurring needs in my React projects.",
   },
   {
+    slug: "vani-club",
     name: "vani.club",
     description:
       "YouTube team collaboration, direct uploads, and AI magic for effortless content creation!",
     link: "https://vani-club.vercel.app",
     inactive: true,
+    role: "Creator and full-stack engineer",
+    stack: ["Next.js", "YouTube API", "AI"],
+    summary: "I explored a collaborative workflow for YouTube teams, including uploads and AI-assisted content operations.",
   },
   {
+    slug: "section-fyi",
     name: "section.fyi",
     description:
       "Build a custom page with multiple links for effortless online presence!",
     link: "https://section.fyi",
     inactive: true,
+    role: "Creator",
+    stack: ["Next.js", "TypeScript"],
+    summary: "I built a customizable link-in-bio page product and learned from taking a small product from idea to deployment.",
   },
 ];
 
@@ -106,7 +135,7 @@ export const experiences = [
     location: "Pune, India",
     positions: [
       {
-        name: "Founding FullStack Developer",
+        name: "Founding Full-Stack Engineer",
         fromToTill: "Jan 2024",
         type: "Full-Time",
         notes: [
@@ -120,7 +149,7 @@ export const experiences = [
     location: "Remote, India",
     positions: [
       {
-        name: "FullStack Engineer",
+        name: "Full-Stack Engineer",
         fromToTill: "Jul 2023 - Jan 2024",
         type: "Full-Time",
         notes: [

--- a/src/content/blogs/2025.mdx
+++ b/src/content/blogs/2025.mdx
@@ -1,6 +1,7 @@
 ---
 title: Looking Back at 2025
 description: A look back at 2025, grateful for the lessons, the love, and the calm it brought along the way.
+image: /og.png
 date: 2025-12-26
 ---
 

--- a/src/content/blogs/css-only-tooltips.mdx
+++ b/src/content/blogs/css-only-tooltips.mdx
@@ -1,6 +1,7 @@
 ---
 title: Create Tooltips Using CSS Only
 description: Many folks make the mistake of choosing heavy libraries just to show tooltips in a web app, whereas you can do it with just a few lines of CSS.
+image: /og.png
 date: 2025-08-30
 ---
 

--- a/src/content/blogs/keep-it-narrow.mdx
+++ b/src/content/blogs/keep-it-narrow.mdx
@@ -1,6 +1,7 @@
 ---
 title: Keep it Narrow and Simple
 description: why you need to keep your goal, circle and life simple and narrow to achieve the best out of it.
+image: /blog/keep-it-narrow.png
 date: 2024-02-25
 published: false
 ---

--- a/src/content/blogs/life-update.mdx
+++ b/src/content/blogs/life-update.mdx
@@ -1,6 +1,7 @@
 ---
 title: How Life Is Going as a 20-Year-Old Non-CS Software Engineer
 description: Hey all, this is a life update on how things are going as a 20-year-old non-CS software engineer. Here, I'll talk about my experiences and what I've learned so far.
+image: /blog/life-update.png
 date: 2024-02-03
 ---
 

--- a/src/content/blogs/living-in-golden-era.mdx
+++ b/src/content/blogs/living-in-golden-era.mdx
@@ -1,6 +1,7 @@
 ---
 title: I feel like I'm living in the Golden Era.
 description: shared my thoughts on remarkable technological advancements and human civilization's growth.
+image: /blog/living-in-golden-era.png
 date: 2024-02-11
 ---
 

--- a/src/content/blogs/most-used-llm-terms.mdx
+++ b/src/content/blogs/most-used-llm-terms.mdx
@@ -1,6 +1,7 @@
 ---
 title: Most Used terms in LLMs (large language models)
 description: Hey all, I'm currently working with LLMs and have come across some common model terms that are technical and not very self-explanatory. So, I thought I would share them with all of you.
+image: /blog/most-used-llm-terms.png
 date: 2024-03-05
 ---
 

--- a/src/content/blogs/my-scrap-shelf.mdx
+++ b/src/content/blogs/my-scrap-shelf.mdx
@@ -1,6 +1,7 @@
 ---
 title: My Scrap Shelf
 description: Let's chat about some of the projects I worked on so far. Some of them didn't quite go as planned and a few are doing well.
+image: /blog/my-scrap-shelf.png
 date: 2024-12-09
 published: true
 ---

--- a/src/content/blogs/scared-from-devin.mdx
+++ b/src/content/blogs/scared-from-devin.mdx
@@ -1,6 +1,7 @@
 ---
 title: I'm scared of Devin (an AI software engineer)
 description: Delve into my personal insights on the future of software engineering amidst the emergence of AI tools like Devin. Navigate uncertainties, embrace innovation, and carve your unique path in this ever-evolving landscape.
+image: /blog/scared-from-devin.png
 date: 2024-03-21
 ---
 
@@ -60,6 +61,6 @@ The best course of action is to invest in yourself. Keep learning and growing, m
 
 So, let's channel our efforts into building the best software solutions that can truly make a difference in people's lives. Let's leave our mark on the world through our creativity, ingenuity, and dedication to excellence.
 
-if you have to say something regarding this, feel free to reach out to me on [Twitter](https://twitter.com/elision_ims) or my inbox at [hello@suresh.im](hello@suresh.im) is always open for you.
+if you have to say something regarding this, feel free to reach out to me on [Twitter](https://twitter.com/elision_ims) or my inbox at [hello@suresh.im](mailto:hello@suresh.im) is always open for you.
 
 Go back [Home](/).

--- a/src/content/blogs/struggling-to-read.mdx
+++ b/src/content/blogs/struggling-to-read.mdx
@@ -1,6 +1,7 @@
 ---
 title: I'm Losing My Reading Ability
 description: Note to myself and fellow developers who might be experiencing the same thing.
+image: /blog/struggling-to-read.png
 date: 2025-08-27
 published: true
 ---

--- a/src/content/blogs/you-cant-make-link-shortner-service-fast.mdx
+++ b/src/content/blogs/you-cant-make-link-shortner-service-fast.mdx
@@ -1,6 +1,7 @@
 ---
 title: Why Link Shortener Services Can’t Be Made Faster
 description: Understanding why link shortener services face inherent speed constraints and what we can do about it
+image: /blog/you-cant-make-link-shortner-service-fast.png
 date: 2024-05-25
 published: true
 ---

--- a/src/lib/mdx.ts
+++ b/src/lib/mdx.ts
@@ -15,6 +15,8 @@ export interface BlogFrontmatter {
   description: string;
   date: string;
   published: boolean;
+  updated?: string;
+  image?: string;
 }
 
 export interface Blog extends BlogFrontmatter {
@@ -35,11 +37,13 @@ export function getAllBlogs(): Blog[] {
 
       return {
         slug,
-        url: `blog/${slug}`,
+        url: `/blog/${slug}`,
         title: data.title,
         description: data.description,
         date: data.date,
         published: data.published ?? true,
+        updated: data.updated,
+        image: data.image,
         content,
       } as Blog;
     });
@@ -55,11 +59,13 @@ export function getBlogBySlug(slug: string): Blog | null {
 
     return {
       slug,
-      url: `blog/${slug}`,
+      url: `/blog/${slug}`,
       title: data.title,
       description: data.description,
       date: data.date,
       published: data.published ?? true,
+      updated: data.updated,
+      image: data.image,
       content,
     } as Blog;
   } catch {
@@ -108,4 +114,3 @@ export async function serializeMDX(content: string) {
     mdxOptions,
   });
 }
-

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -38,5 +38,5 @@ export function proxy(req: NextRequest) {
 }
 
 export const config = {
-  matcher: ["/", "/blog/:path*"],
+  matcher: ["/", "/about", "/projects", "/contact", "/blog/:path*"],
 };


### PR DESCRIPTION
### Motivation

- Establish `https://sureshchaudhary.com` as the single canonical identity for the personal brand to avoid split signals and ensure consistent metadata and structured data across the site.  
- Fix malformed blog canonicals/Open Graph URLs and prevent drafts from being indexable so search engines and crawlers see accurate article URLs and previews.  
- Improve discoverability and AI-readability by adding persistent internal navigation, first-party project case pages, reliable sitemap dates, and expanded markdown endpoints for About/Projects/Contact and `llms.txt` material.

### Description

- Centralized canonical identity and enhanced project data by updating `externals.base_url` and `externals.referrer` and enriching `projects` with `slug`, `role`, `stack`, `summary`, and `article` fields in `src/constant/data.ts`.  
- Fixed blog URL handling and frontmatter support by normalizing `url` to include a leading slash, adding optional `image`/`updated` frontmatter, making `getAllBlogs()`/`getBlogBySlug()` expose those fields, and updating `src/app/blog/[slug]/page.tsx` to build absolute canonicals, use article `image` fallbacks, emit `BlogPosting` JSON-LD, and return `notFound()` for unpublished drafts.  
- Removed the global hard-coded homepage `<link rel="canonical">` and empty verification meta, switched to env-driven verification via `metadata.verification`, corrected the Person/WebSite graph, rendered the `Footer`, and added accessible brand text and persistent navigation links in `src/app/layout.tsx`, `src/components/custom/navbar.tsx`, and `src/components/custom/footer.tsx`.  
- Added first-party project detail routes at `src/app/projects/[slug]/page.tsx`, created Markdown endpoints for `About`, `Projects`, and `Contact` under `src/app/md/*`, regenerated `public/llms.txt` around the `.com` identity and added `public/llms-full.txt`, and adjusted `src/proxy.ts` to include these markdown routes in content negotiation.  
- Improved link/referrer behavior by updating `src/components/custom/link.tsx` to stop appending a `ref` parameter to every external URL and introduced a `withReferrer` option that uses the `URL` API; fixed blog list links in `src/components/custom/blog-row.tsx` to use canonical paths.  
- Improved sitemap generation in `src/app/sitemap.ts` to exclude drafts, use content-backed modification dates (`updated ?? date`), and include project detail pages; added host-preserving redirects in `next.config.js` to route `suresh.im` and `www.sureshchaudhary.com` to the canonical apex.  
- Minor UX/compatibility fixes such as avoiding synchronous `setState` inside layout effects in `src/components/custom/theme-toggle.tsx` and correcting malformed mail links in content files to `mailto:` where appropriate.

### Testing

- Ran linting with `pnpm lint` and static checks which completed (notes: `browserslist`/`baseline-browser-mapping` informational messages were shown).  
- Type-checking succeeded with `pnpm exec tsc --noEmit`.  
- `git diff --check` and repository checks passed with no blocking errors in the modified files.  
- Attempted `pnpm build` but the Next.js font fetch failed in this environment because `next/font` could not download the `Newsreader` font from Google (build error unrelated to the site logic changes); this is an environment/network issue and should succeed in normal CI or after allowing outbound fetches or bundling fonts.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7c2e4c2cf88326b7be41d9075d121b)