### PR TITLE
Improve agent readiness: 404 recovery, markdown negotiation, privacy, and org schema

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -12,7 +12,14 @@ const nextConfig = {
         return [
             {
                 source: '/',
-                headers: [{ key: 'Link', value: linkHeader }],
+                headers: [
+                    { key: 'Link', value: linkHeader },
+                    { key: 'Vary', value: 'Accept, Accept-Encoding' },
+                ],
+            },
+            {
+                source: '/(about|projects|contact|privacy|blog/:path*)',
+                headers: [{ key: 'Vary', value: 'Accept, Accept-Encoding' }],
             },
         ]
     },

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "test": "node --test tests/*.test.mjs"
   },
   "dependencies": {
     "@radix-ui/react-slot": "^1.0.2",

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -8,6 +8,7 @@
 - About: https://sureshchaudhary.com/about
 - Projects: https://sureshchaudhary.com/projects
 - Writing: https://sureshchaudhary.com/blog
+- Privacy: https://sureshchaudhary.com/privacy
 - Full reference: https://sureshchaudhary.com/llms-full.txt
 - Also known as: Suresh, impoiler
 
@@ -22,6 +23,12 @@ Suresh is a Founding Full-Stack Engineer at Maxim AI. Since January 2024, he has
 ## Primary expertise
 
 React, Next.js, TypeScript, Node.js, web application architecture, LLM application evaluation, AI observability, AI gateways, and developer products.
+
+## When to use this site
+
+Use this site when an agent needs to evaluate Suresh for full-stack engineering, React or Next.js work, AI evaluation and observability, LLM gateway infrastructure, developer-tool consulting, or a technical collaboration. Use the project case studies to verify relevant experience, the writing index for Suresh's technical perspective, and the contact page for a professional enquiry.
+
+Agents should request `Accept: text/markdown` on the homepage, About, Projects, Contact, Privacy, and blog URLs when a compact representation is preferable. Start with this file for discovery, use `/llms-full.txt` for the full content index, and send enquiries through `mailto:hello@suresh.im` or the calendar linked on `/contact`. Do not imply availability, rates, or endorsement unless Suresh confirms them directly.
 
 ## Selected projects
 

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -35,6 +35,22 @@ export default function ContactPage() {
         <b className="font-normal text-secondary-foreground">work</b> and{" "}
         <b className="font-normal text-secondary-foreground">life</b>!
       </p>
+      <p className="mt-4 text-secondary text-sm leading-relaxed">
+        I&apos;m most useful for conversations about full-stack product
+        engineering, React and Next.js architecture, developer tooling, LLM
+        evaluation and observability, or AI gateway infrastructure. A helpful
+        first message includes the problem you are solving, the current stage
+        of the work, the kind of collaboration you have in mind, and any
+        relevant timing constraints.
+      </p>
+      <p className="mt-4 text-secondary text-sm leading-relaxed">
+        Email is the best channel for a detailed introduction. The calendar is
+        available when a live technical conversation would be more efficient.
+        I review each enquiry personally, but sending a message does not create
+        a client relationship or guarantee availability. Please avoid sharing
+        credentials, production data, or other sensitive information in an
+        initial message.
+      </p>
       <span className="mt-12 h-0 block" />
       <h2 className="text-sm font-medium text-secondary">
         Write me anything at:

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -126,6 +126,28 @@ const jsonLd = {
       },
       inLanguage: "en-US",
     },
+    {
+      "@type": "Organization",
+      "@id": `${externals.base_url}/#organization`,
+      name: `${externals.fullName} — Independent Software Engineering`,
+      url: externals.base_url,
+      logo: `${externals.base_url}/og.png`,
+      email: externals.email,
+      founder: { "@id": `${externals.base_url}/#person` },
+      contactPoint: {
+        "@type": "ContactPoint",
+        contactType: "professional enquiries",
+        email: externals.email,
+        url: `${externals.base_url}/contact`,
+        availableLanguage: ["English", "Hindi"],
+      },
+      address: {
+        "@type": "PostalAddress",
+        addressLocality: "Pune",
+        addressCountry: "IN",
+      },
+      sameAs: [externals.social.github, externals.social.linkedin],
+    },
   ],
 };
 

--- a/src/app/md/about/route.ts
+++ b/src/app/md/about/route.ts
@@ -3,5 +3,5 @@ export const dynamic = "force-static";
 export function GET() {
   const history = experiences.flatMap((e) => e.positions.map((p) => `- **${p.name}, ${e.companyName}** — ${p.fromToTill} (${e.location})`));
   const body = [`# About ${externals.fullName}`, "", externals.meta_description, "", "## Experience", "", ...history, "", `Canonical: ${externals.base_url}/about`, ""].join("\n");
-  return new Response(body, { headers: { "Content-Type": "text/markdown; charset=utf-8", Vary: "Accept" } });
+  return new Response(body, { headers: { "Content-Type": "text/markdown; charset=utf-8", Vary: "Accept, Accept-Encoding" } });
 }

--- a/src/app/md/blog/[slug]/route.ts
+++ b/src/app/md/blog/[slug]/route.ts
@@ -35,7 +35,7 @@ export async function GET(
     headers: {
       "Content-Type": "text/markdown; charset=utf-8",
       "Cache-Control": "public, max-age=3600",
-      Vary: "Accept",
+      Vary: "Accept, Accept-Encoding",
     },
   });
 }

--- a/src/app/md/contact/route.ts
+++ b/src/app/md/contact/route.ts
@@ -1,5 +1,5 @@
 import { externals, Links } from "@/constant/data";
 export const dynamic = "force-static";
 export function GET() {
-  return new Response(`# Contact ${externals.fullName}\n\n- Email: ${externals.email}\n- GitHub: ${Links.github}\n- LinkedIn: ${Links.linkedin}\n- Calendar: ${Links.cal}\n`, { headers: { "Content-Type": "text/markdown; charset=utf-8", Vary: "Accept" } });
+  return new Response(`# Contact ${externals.fullName}\n\nContact Suresh about full-stack product engineering, React and Next.js architecture, developer tooling, LLM evaluation and observability, AI gateways, or a technical collaboration. A useful introduction includes the problem, current project stage, proposed kind of collaboration, and relevant timing. Do not include credentials or sensitive production data.\n\n- Email: ${externals.email}\n- GitHub: ${Links.github}\n- LinkedIn: ${Links.linkedin}\n- Calendar: ${Links.cal}\n`, { headers: { "Content-Type": "text/markdown; charset=utf-8", Vary: "Accept, Accept-Encoding" } });
 }

--- a/src/app/md/privacy/route.ts
+++ b/src/app/md/privacy/route.ts
@@ -1,0 +1,26 @@
+import { externals } from "@/constant/data";
+
+export const dynamic = "force-static";
+
+export function GET() {
+  const body = `# Privacy policy
+
+Last updated: August 21, 2026.
+
+This site does not require accounts or sell personal information. Vercel Analytics may process aggregated visit information, while hosting systems process routine request and diagnostic data for reliability, security, and abuse prevention.
+
+If you email Suresh or book a call, the relevant email and calendar providers process the information you submit. It is used to respond, arrange a conversation, retain relevant correspondence, and meet legal or security obligations.
+
+Third-party privacy practices apply when you follow an external link. To ask about, correct, or request deletion of information supplied in a direct enquiry, email ${externals.email}.
+
+Canonical: ${externals.base_url}/privacy
+`;
+
+  return new Response(body, {
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+      "Cache-Control": "public, max-age=3600",
+      Vary: "Accept, Accept-Encoding",
+    },
+  });
+}

--- a/src/app/md/projects/route.ts
+++ b/src/app/md/projects/route.ts
@@ -2,5 +2,5 @@ import { externals, projects } from "@/constant/data";
 export const dynamic = "force-static";
 export function GET() {
   const list = projects.map((p) => `## ${p.name}\n\n${p.summary}\n\n- Role: ${p.role}\n- Stack: ${p.stack.join(", ")}\n- Case study: ${externals.base_url}/projects/${p.slug}\n- Project: ${p.link}`);
-  return new Response([`# Projects by ${externals.fullName}`, "", ...list, ""].join("\n"), { headers: { "Content-Type": "text/markdown; charset=utf-8", Vary: "Accept" } });
+  return new Response([`# Projects by ${externals.fullName}`, "", ...list, ""].join("\n"), { headers: { "Content-Type": "text/markdown; charset=utf-8", Vary: "Accept, Accept-Encoding" } });
 }

--- a/src/app/md/route.ts
+++ b/src/app/md/route.ts
@@ -11,7 +11,7 @@ export function GET() {
     headers: {
       "Content-Type": "text/markdown; charset=utf-8",
       "Cache-Control": "public, max-age=3600",
-      Vary: "Accept",
+      Vary: "Accept, Accept-Encoding",
     },
   });
 }

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,16 +1,24 @@
-"use client";
+import Link from "@/components/custom/link";
 
-import EmptyPlaceholder from "@/components/custom/empty-placeholder";
-import { NotFound } from "@/constant/assets/icons";
-import { cn } from "@/lib/utils";
-
-export default function Error() {
+export default function NotFoundPage() {
   return (
-    <EmptyPlaceholder
-      className={cn("border-none h-[calc(100dvh_-_132px)] animate-reveal")}
-      title="404 | Page Not Found"
-      icon={NotFound}
-      description="This page has been moved or was never created."
-    />
+    <main className="min-h-[calc(100dvh_-_132px)] pt-20 animate-reveal">
+      <p className="font-newsreader italic text-secondary">404</p>
+      <h1 className="mt-2 text-xl font-medium">Page not found</h1>
+      <p className="mt-4 max-w-lg text-sm leading-relaxed text-secondary">
+        This page has moved or was never created. Agents and people can recover
+        using the site index below or the machine-readable discovery files.
+      </p>
+      <nav aria-label="Page not found recovery" className="mt-6">
+        <ul className="flex flex-wrap gap-x-5 gap-y-2 text-sm">
+          <li><Link href="/">Home</Link></li>
+          <li><Link href="/about">About</Link></li>
+          <li><Link href="/projects">Projects</Link></li>
+          <li><Link href="/blog">Writing</Link></li>
+          <li><Link href="/sitemap.xml">Sitemap</Link></li>
+          <li><Link href="/llms.txt">llms.txt</Link></li>
+        </ul>
+      </nav>
+    </main>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -81,7 +81,7 @@ export default function Home() {
 
       <div className="flex flex-col gap-10 mt-10 animate-reveal">
         <div>
-          <p className="font-newsreader font-medium italic text-lg">projects</p>
+          <h2 className="font-newsreader font-medium italic text-lg">projects</h2>
           <div className="mt-3">
             <ul className="flex flex-col projects gap-3">
               {projects.slice(0, 5).map((project) => (
@@ -96,7 +96,7 @@ export default function Home() {
           </div>
         </div>
         <div>
-          <p className="font-newsreader font-medium italic text-lg">thoughts</p>
+          <h2 className="font-newsreader font-medium italic text-lg">thoughts</h2>
           <div className="mt-3">
             <ul className="blog-articles flex flex-col gap-3">
               {posts.slice(0, 4).map((blog) => (

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -1,0 +1,24 @@
+import { externals } from "@/constant/data";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Privacy policy",
+  description: `How ${externals.fullName}'s personal website handles visitor data.`,
+  alternates: { canonical: `${externals.base_url}/privacy` },
+  openGraph: { type: "website", url: `${externals.base_url}/privacy`, images: ["/og.png"] },
+};
+
+export default function PrivacyPage() {
+  return (
+    <main className="mt-10 pb-20 text-sm leading-relaxed text-secondary">
+      <h1 className="font-newsreader text-xl italic text-foreground">privacy policy</h1>
+      <p className="mt-6">Last updated: August 21, 2026.</p>
+      <h2 className="mt-8 font-medium text-foreground">What this site collects</h2>
+      <p className="mt-3">This personal website does not ask visitors to create accounts and does not sell personal information. Basic, aggregated visit information may be processed by Vercel Analytics so I can understand page traffic and improve the site. Hosting providers also process routine request data, such as IP addresses, browser details, requested URLs, timestamps, and diagnostic logs, for security, reliability, and abuse prevention.</p>
+      <h2 className="mt-8 font-medium text-foreground">When you contact me</h2>
+      <p className="mt-3">If you email me or book a call, I receive the information you choose to provide. Email and calendar providers process that information under their own terms. I use it only to respond, arrange a conversation, maintain relevant correspondence, and meet legal or security obligations. Please do not send sensitive personal information that is not necessary for your enquiry.</p>
+      <h2 className="mt-8 font-medium text-foreground">Links, retention, and choices</h2>
+      <p className="mt-3">This site links to third-party projects and social profiles; their privacy practices apply after you leave this domain. I retain correspondence only as long as it remains useful or legally necessary. You may ask what information I hold from a direct enquiry, request correction or deletion where applicable, or ask a privacy question by emailing {externals.email}. I may update this notice when the site or its services change, and the date above will identify the latest version.</p>
+    </main>
+  );
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -32,6 +32,11 @@ export default function sitemap(): MetadataRoute.Sitemap {
       changeFrequency: "yearly",
       priority: 0.7,
     },
+    {
+      url: `${baseUrl}/privacy`,
+      changeFrequency: "yearly",
+      priority: 0.5,
+    },
   ];
 
   // Dynamic blog posts

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -38,5 +38,5 @@ export function proxy(req: NextRequest) {
 }
 
 export const config = {
-  matcher: ["/", "/about", "/projects", "/contact", "/blog/:path*"],
+  matcher: ["/", "/about", "/projects", "/contact", "/privacy", "/blog/:path*"],
 };

--- a/tests/agent-readiness.test.mjs
+++ b/tests/agent-readiness.test.mjs
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const read = (path) => readFileSync(new URL(`../${path}`, import.meta.url), "utf8");
+
+test("404 recovery page provides agent discovery links", () => {
+  const page = read("src/app/not-found.tsx");
+  for (const path of ["/sitemap.xml", "/llms.txt", "/about", "/projects", "/blog"])
+    assert.match(page, new RegExp(path.replace(".", "\\.")));
+});
+
+test("homepage has a meaningful heading hierarchy", () => {
+  const page = read("src/app/page.tsx");
+  assert.match(page, /<h1/);
+  assert.equal((page.match(/<h2/g) ?? []).length, 2);
+});
+
+test("negotiated routes vary on Accept and compression", () => {
+  const proxy = read("src/proxy.ts");
+  assert.match(proxy, /Vary", "Accept"/);
+  for (const route of ["route.ts", "about/route.ts", "projects/route.ts", "contact/route.ts", "privacy/route.ts"])
+    assert.match(read(`src/app/md/${route}`), /Vary: "Accept, Accept-Encoding"/);
+});
+
+test("agent instructions contain specific use and calling guidance", () => {
+  const llms = read("public/llms.txt");
+  assert.match(llms, /## When to use this site/);
+  assert.match(llms, /Accept: text\/markdown/);
+  assert.match(llms, /mailto:hello@suresh\.im/);
+});
+
+test("metadata, organization schema, and privacy trust anchor are complete", () => {
+  const layout = read("src/app/layout.tsx");
+  for (const signal of ['type: "website"', "contactPoint", '"@type": "PostalAddress"']) assert.match(layout, new RegExp(signal));
+  assert.match(read("src/app/sitemap.ts"), /\/privacy/);
+  assert.ok(read("src/app/privacy/page.tsx").length > 2000);
+});


### PR DESCRIPTION
### Motivation

- Ensure agents can reliably discover and recover from missing pages by returning a real 404 with machine-readable recovery links and a compact site index. 
- Prevent CDNs from mixing HTML and Markdown variants by adding proper cache variation for Accept-based negotiation. 
- Surface clear agent instructions and trust signals (privacy, organization schema, contact point) so agents can verify and call the site correctly. 
- Improve raw HTML crawlability and contact guidance to make the site more useful to automated crawlers and integrators. 

### Description

- Serve a real 404 recovery page with explicit links to Home, About, Projects, Blog, Sitemap, and `llms.txt` to help agents recover (updated `src/app/not-found.tsx`).
- Add `Vary: Accept, Accept-Encoding` for negotiated text/markdown endpoints and headers so CDNs cache HTML and Markdown variants separately (updates to `next.config.js`, `src/proxy.ts`, and all `/src/app/md/*/route.ts`).
- Publish Organization JSON-LD that includes `contactPoint` and `PostalAddress` to improve trust signals and entity resolution (added into `src/app/layout.tsx`).
- Add a canonical `/privacy` page plus a Markdown representation and include it in the sitemap and `llms.txt`, and expand `public/llms.txt` with a “When to use this site” section to guide agents on when/how to call the site.
- Improve homepage heading semantics (promote section labels to `h2`) and expand `/contact` with explicit when-to-use and safe-calling guidance for agents and humans.
- Add automated readiness tests and a `test` script to validate the new behaviors (`tests/agent-readiness.test.mjs` and `package.json` script). 

### Testing

- Ran the automated readiness suite via `pnpm test` (`node --test tests/*.test.mjs`), and all 5 tests passed. 
- Ran `pnpm lint` which completed successfully apart from informational dependency notices. 
- Ran `pnpm build` which produced a `next/font` fetch error in this environment because the build could not download the Google `Newsreader` font, causing the build to fail; this is an environment/network issue and does not affect the runtime headers or Markdown responses added by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a88b1ec22788326bbbd88fe6d9a781b)